### PR TITLE
Update MWAA cfn resource provider with endpoint management changes

### DIFF
--- a/aws-mwaa-environment/aws-mwaa-environment.json
+++ b/aws-mwaa-environment/aws-mwaa-environment.json
@@ -21,7 +21,8 @@
         "DELETING",
         "DELETED",
         "UPDATE_FAILED",
-        "UNAVAILABLE"
+        "UNAVAILABLE",
+        "PENDING"
       ]
     },
     "UpdateStatus": {
@@ -324,6 +325,29 @@
         "PRIVATE_ONLY",
         "PUBLIC_ONLY"
       ]
+    },
+    "EndpointManagement": {
+      "type": "string",
+      "description": "Defines whether the VPC endpoints configured for the environment are created, and managed, by the customer or by Amazon MWAA.",
+      "enum": [
+        "CUSTOMER",
+        "SERVICE"
+      ]
+    },
+    "CeleryExecutorQueue": {
+      "type": "string",
+      "description": "The celery executor queue associated with the environment.",
+      "maxLength": 1224
+    },
+    "DatabaseVpcEndpointService": {
+      "type": "string",
+      "description": "The database VPC endpoint service name.",
+      "maxLength": 1224
+    },
+    "WebserverVpcEndpointService": {
+      "type": "string",
+      "description": "The webserver VPC endpoint service name, applicable if private webserver access mode selected.",
+      "maxLength": 1224
     }
   },
   "properties": {
@@ -400,6 +424,18 @@
     },
     "WebserverAccessMode": {
       "$ref": "#/definitions/WebserverAccessMode"
+    },
+    "EndpointManagement": {
+      "$ref": "#/definitions/EndpointManagement"
+    },
+    "CeleryExecutorQueue": {
+      "$ref": "#/definitions/CeleryExecutorQueue"
+    },
+    "DatabaseVpcEndpointService": {
+      "$ref": "#/definitions/DatabaseVpcEndpointService"
+    },
+    "WebserverVpcEndpointService": {
+      "$ref": "#/definitions/WebserverVpcEndpointService"
     }
   },
   "additionalProperties": false,
@@ -409,10 +445,14 @@
   "createOnlyProperties": [
     "/properties/Name",
     "/properties/KmsKey",
-    "/properties/NetworkConfiguration/SubnetIds"
+    "/properties/NetworkConfiguration/SubnetIds",
+    "/properties/EndpointManagement"
   ],
   "readOnlyProperties": [
     "/properties/Arn",
+    "/properties/CeleryExecutorQueue",
+    "/properties/DatabaseVpcEndpointService",
+    "/properties/WebserverVpcEndpointService",
     "/properties/WebserverUrl",
     "/properties/LoggingConfiguration/DagProcessingLogs/CloudWatchLogGroupArn",
     "/properties/LoggingConfiguration/SchedulerLogs/CloudWatchLogGroupArn",

--- a/aws-mwaa-environment/docs/README.md
+++ b/aws-mwaa-environment/docs/README.md
@@ -1,0 +1,433 @@
+# AWS::MWAA::Environment
+
+Resource schema for AWS::MWAA::Environment
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "AWS::MWAA::Environment",
+    "Properties" : {
+        "<a href="#name" title="Name">Name</a>" : <i>String</i>,
+        "<a href="#executionrolearn" title="ExecutionRoleArn">ExecutionRoleArn</a>" : <i>String</i>,
+        "<a href="#kmskey" title="KmsKey">KmsKey</a>" : <i>String</i>,
+        "<a href="#airflowversion" title="AirflowVersion">AirflowVersion</a>" : <i>String</i>,
+        "<a href="#sourcebucketarn" title="SourceBucketArn">SourceBucketArn</a>" : <i>String</i>,
+        "<a href="#dags3path" title="DagS3Path">DagS3Path</a>" : <i>String</i>,
+        "<a href="#pluginss3path" title="PluginsS3Path">PluginsS3Path</a>" : <i>String</i>,
+        "<a href="#pluginss3objectversion" title="PluginsS3ObjectVersion">PluginsS3ObjectVersion</a>" : <i>String</i>,
+        "<a href="#requirementss3path" title="RequirementsS3Path">RequirementsS3Path</a>" : <i>String</i>,
+        "<a href="#requirementss3objectversion" title="RequirementsS3ObjectVersion">RequirementsS3ObjectVersion</a>" : <i>String</i>,
+        "<a href="#startupscripts3path" title="StartupScriptS3Path">StartupScriptS3Path</a>" : <i>String</i>,
+        "<a href="#startupscripts3objectversion" title="StartupScriptS3ObjectVersion">StartupScriptS3ObjectVersion</a>" : <i>String</i>,
+        "<a href="#airflowconfigurationoptions" title="AirflowConfigurationOptions">AirflowConfigurationOptions</a>" : <i>Map</i>,
+        "<a href="#environmentclass" title="EnvironmentClass">EnvironmentClass</a>" : <i>String</i>,
+        "<a href="#maxworkers" title="MaxWorkers">MaxWorkers</a>" : <i>Integer</i>,
+        "<a href="#minworkers" title="MinWorkers">MinWorkers</a>" : <i>Integer</i>,
+        "<a href="#schedulers" title="Schedulers">Schedulers</a>" : <i>Integer</i>,
+        "<a href="#networkconfiguration" title="NetworkConfiguration">NetworkConfiguration</a>" : <i><a href="networkconfiguration.md">NetworkConfiguration</a></i>,
+        "<a href="#loggingconfiguration" title="LoggingConfiguration">LoggingConfiguration</a>" : <i><a href="loggingconfiguration.md">LoggingConfiguration</a></i>,
+        "<a href="#weeklymaintenancewindowstart" title="WeeklyMaintenanceWindowStart">WeeklyMaintenanceWindowStart</a>" : <i>String</i>,
+        "<a href="#tags" title="Tags">Tags</a>" : <i>Map</i>,
+        "<a href="#webserveraccessmode" title="WebserverAccessMode">WebserverAccessMode</a>" : <i>String</i>,
+        "<a href="#endpointmanagement" title="EndpointManagement">EndpointManagement</a>" : <i>String</i>,
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: AWS::MWAA::Environment
+Properties:
+    <a href="#name" title="Name">Name</a>: <i>String</i>
+    <a href="#executionrolearn" title="ExecutionRoleArn">ExecutionRoleArn</a>: <i>String</i>
+    <a href="#kmskey" title="KmsKey">KmsKey</a>: <i>String</i>
+    <a href="#airflowversion" title="AirflowVersion">AirflowVersion</a>: <i>String</i>
+    <a href="#sourcebucketarn" title="SourceBucketArn">SourceBucketArn</a>: <i>String</i>
+    <a href="#dags3path" title="DagS3Path">DagS3Path</a>: <i>String</i>
+    <a href="#pluginss3path" title="PluginsS3Path">PluginsS3Path</a>: <i>String</i>
+    <a href="#pluginss3objectversion" title="PluginsS3ObjectVersion">PluginsS3ObjectVersion</a>: <i>String</i>
+    <a href="#requirementss3path" title="RequirementsS3Path">RequirementsS3Path</a>: <i>String</i>
+    <a href="#requirementss3objectversion" title="RequirementsS3ObjectVersion">RequirementsS3ObjectVersion</a>: <i>String</i>
+    <a href="#startupscripts3path" title="StartupScriptS3Path">StartupScriptS3Path</a>: <i>String</i>
+    <a href="#startupscripts3objectversion" title="StartupScriptS3ObjectVersion">StartupScriptS3ObjectVersion</a>: <i>String</i>
+    <a href="#airflowconfigurationoptions" title="AirflowConfigurationOptions">AirflowConfigurationOptions</a>: <i>Map</i>
+    <a href="#environmentclass" title="EnvironmentClass">EnvironmentClass</a>: <i>String</i>
+    <a href="#maxworkers" title="MaxWorkers">MaxWorkers</a>: <i>Integer</i>
+    <a href="#minworkers" title="MinWorkers">MinWorkers</a>: <i>Integer</i>
+    <a href="#schedulers" title="Schedulers">Schedulers</a>: <i>Integer</i>
+    <a href="#networkconfiguration" title="NetworkConfiguration">NetworkConfiguration</a>: <i><a href="networkconfiguration.md">NetworkConfiguration</a></i>
+    <a href="#loggingconfiguration" title="LoggingConfiguration">LoggingConfiguration</a>: <i><a href="loggingconfiguration.md">LoggingConfiguration</a></i>
+    <a href="#weeklymaintenancewindowstart" title="WeeklyMaintenanceWindowStart">WeeklyMaintenanceWindowStart</a>: <i>String</i>
+    <a href="#tags" title="Tags">Tags</a>: <i>Map</i>
+    <a href="#webserveraccessmode" title="WebserverAccessMode">WebserverAccessMode</a>: <i>String</i>
+    <a href="#endpointmanagement" title="EndpointManagement">EndpointManagement</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Name
+
+Customer-defined identifier for the environment, unique per customer region.
+
+_Required_: Yes
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>80</code>
+
+_Pattern_: <code>^[a-zA-Z][0-9a-zA-Z\-_]*$</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### ExecutionRoleArn
+
+IAM role to be used by tasks.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1224</code>
+
+_Pattern_: <code>^arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b)(-[a-z]+)?:iam::\d{12}:role/?[a-zA-Z_0-9+=,.@\-_/]+$</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### KmsKey
+
+The identifier of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use for MWAA data encryption.
+
+    You can specify the CMK using any of the following:
+
+    Key ID. For example, key/1234abcd-12ab-34cd-56ef-1234567890ab.
+
+    Key alias. For example, alias/ExampleAlias.
+
+    Key ARN. For example, arn:aws:kms:us-east-1:012345678910:key/abcd1234-a123-456a-a12b-a123b4cd56ef.
+
+    Alias ARN. For example, arn:aws:kms:us-east-1:012345678910:alias/ExampleAlias.
+
+    AWS authenticates the CMK asynchronously. Therefore, if you specify an ID, alias, or ARN that is not valid, the action can appear to complete, but eventually fails.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1224</code>
+
+_Pattern_: <code>^(((arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b)(-[a-z]+)?:kms:[a-z]{2}-[a-z]+-\d:\d+:)?key\/)?[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}|(arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b):kms:[a-z]{2}-[a-z]+-\d:\d+:)?alias/.+)$</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### AirflowVersion
+
+Version of airflow to deploy to the environment.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>32</code>
+
+_Pattern_: <code>^[0-9a-z.]+$</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### SourceBucketArn
+
+ARN for the AWS S3 bucket to use as the source of DAGs and plugins for the environment.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>1224</code>
+
+_Pattern_: <code>^arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b)(-[a-z]+)?:s3:::[a-z0-9.\-]+$</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### DagS3Path
+
+Represents an S3 prefix relative to the root of an S3 bucket.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Pattern_: <code>.*</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PluginsS3Path
+
+Represents an S3 prefix relative to the root of an S3 bucket.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Pattern_: <code>.*</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PluginsS3ObjectVersion
+
+Represents an version ID for an S3 object.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### RequirementsS3Path
+
+Represents an S3 prefix relative to the root of an S3 bucket.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Pattern_: <code>.*</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### RequirementsS3ObjectVersion
+
+Represents an version ID for an S3 object.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### StartupScriptS3Path
+
+Represents an S3 prefix relative to the root of an S3 bucket.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Pattern_: <code>.*</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### StartupScriptS3ObjectVersion
+
+Represents an version ID for an S3 object.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1024</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### AirflowConfigurationOptions
+
+Key/value pairs representing Airflow configuration variables.
+    Keys are prefixed by their section:
+
+    [core]
+    dags_folder={AIRFLOW_HOME}/dags
+
+    Would be represented as
+
+    "core.dags_folder": "{AIRFLOW_HOME}/dags"
+
+_Required_: No
+
+_Type_: Map
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### EnvironmentClass
+
+Templated configuration for airflow processes and backing infrastructure.
+
+_Required_: No
+
+_Type_: String
+
+_Minimum Length_: <code>1</code>
+
+_Maximum Length_: <code>1024</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MaxWorkers
+
+Maximum worker compute units.
+
+_Required_: No
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### MinWorkers
+
+Minimum worker compute units.
+
+_Required_: No
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Schedulers
+
+Scheduler compute units.
+
+_Required_: No
+
+_Type_: Integer
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### NetworkConfiguration
+
+Configures the network resources of the environment.
+
+_Required_: No
+
+_Type_: <a href="networkconfiguration.md">NetworkConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### LoggingConfiguration
+
+Logging configuration for the environment.
+
+_Required_: No
+
+_Type_: <a href="loggingconfiguration.md">LoggingConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### WeeklyMaintenanceWindowStart
+
+Start time for the weekly maintenance window.
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>9</code>
+
+_Pattern_: <code>(MON|TUE|WED|THU|FRI|SAT|SUN):([01]\d|2[0-3]):(00|30)</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### Tags
+
+A map of tags for the environment.
+
+_Required_: No
+
+_Type_: Map
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### WebserverAccessMode
+
+Choice for mode of webserver access including over public internet or via private VPC endpoint.
+
+_Required_: No
+
+_Type_: String
+
+_Allowed Values_: <code>PRIVATE_ONLY</code> | <code>PUBLIC_ONLY</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### EndpointManagement
+
+Defines whether the VPC endpoints configured for the environment are created, and managed, by the customer or by Amazon MWAA.
+
+_Required_: No
+
+_Type_: String
+
+_Allowed Values_: <code>CUSTOMER</code> | <code>SERVICE</code>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the Name.
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### Arn
+
+ARN for the MWAA environment.
+
+#### CeleryExecutorQueue
+
+The celery executor queue associated with the environment.
+
+#### DatabaseVpcEndpointService
+
+The database VPC endpoint service name.
+
+#### WebserverVpcEndpointService
+
+The webserver VPC endpoint service name, applicable if private webserver access mode selected.
+
+#### WebserverUrl
+
+Url endpoint for the environment's Airflow UI.
+
+#### CloudWatchLogGroupArn
+
+Returns the <code>CloudWatchLogGroupArn</code> value.
+
+#### CloudWatchLogGroupArn
+
+Returns the <code>CloudWatchLogGroupArn</code> value.
+
+#### CloudWatchLogGroupArn
+
+Returns the <code>CloudWatchLogGroupArn</code> value.
+
+#### CloudWatchLogGroupArn
+
+Returns the <code>CloudWatchLogGroupArn</code> value.
+
+#### CloudWatchLogGroupArn
+
+Returns the <code>CloudWatchLogGroupArn</code> value.
+

--- a/aws-mwaa-environment/docs/loggingconfiguration.md
+++ b/aws-mwaa-environment/docs/loggingconfiguration.md
@@ -1,0 +1,74 @@
+# AWS::MWAA::Environment LoggingConfiguration
+
+Logging configuration for the environment.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#dagprocessinglogs" title="DagProcessingLogs">DagProcessingLogs</a>" : <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>,
+    "<a href="#schedulerlogs" title="SchedulerLogs">SchedulerLogs</a>" : <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>,
+    "<a href="#webserverlogs" title="WebserverLogs">WebserverLogs</a>" : <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>,
+    "<a href="#workerlogs" title="WorkerLogs">WorkerLogs</a>" : <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>,
+    "<a href="#tasklogs" title="TaskLogs">TaskLogs</a>" : <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#dagprocessinglogs" title="DagProcessingLogs">DagProcessingLogs</a>: <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>
+<a href="#schedulerlogs" title="SchedulerLogs">SchedulerLogs</a>: <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>
+<a href="#webserverlogs" title="WebserverLogs">WebserverLogs</a>: <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>
+<a href="#workerlogs" title="WorkerLogs">WorkerLogs</a>: <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>
+<a href="#tasklogs" title="TaskLogs">TaskLogs</a>: <i><a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a></i>
+</pre>
+
+## Properties
+
+#### DagProcessingLogs
+
+Logging configuration for a specific airflow component.
+
+_Required_: No
+
+_Type_: <a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### SchedulerLogs
+
+_Required_: No
+
+_Type_: <a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### WebserverLogs
+
+_Required_: No
+
+_Type_: <a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### WorkerLogs
+
+_Required_: No
+
+_Type_: <a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### TaskLogs
+
+_Required_: No
+
+_Type_: <a href="moduleloggingconfiguration.md">ModuleLoggingConfiguration</a>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-mwaa-environment/docs/moduleloggingconfiguration.md
+++ b/aws-mwaa-environment/docs/moduleloggingconfiguration.md
@@ -1,0 +1,58 @@
+# AWS::MWAA::Environment ModuleLoggingConfiguration
+
+Logging configuration for a specific airflow component.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#enabled" title="Enabled">Enabled</a>" : <i>Boolean</i>,
+    "<a href="#loglevel" title="LogLevel">LogLevel</a>" : <i>String</i>,
+    "<a href="#cloudwatchloggrouparn" title="CloudWatchLogGroupArn">CloudWatchLogGroupArn</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#enabled" title="Enabled">Enabled</a>: <i>Boolean</i>
+<a href="#loglevel" title="LogLevel">LogLevel</a>: <i>String</i>
+<a href="#cloudwatchloggrouparn" title="CloudWatchLogGroupArn">CloudWatchLogGroupArn</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### Enabled
+
+_Required_: No
+
+_Type_: Boolean
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### LogLevel
+
+_Required_: No
+
+_Type_: String
+
+_Allowed Values_: <code>CRITICAL</code> | <code>ERROR</code> | <code>WARNING</code> | <code>INFO</code> | <code>DEBUG</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### CloudWatchLogGroupArn
+
+_Required_: No
+
+_Type_: String
+
+_Maximum Length_: <code>1224</code>
+
+_Pattern_: <code>^arn:(aws|aws-us-gov|aws-cn|aws-iso|aws-iso-b)(-[a-z]+)?:logs:[a-z0-9\-]+:\d{12}:log-group:\w+</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-mwaa-environment/docs/networkconfiguration.md
+++ b/aws-mwaa-environment/docs/networkconfiguration.md
@@ -1,0 +1,48 @@
+# AWS::MWAA::Environment NetworkConfiguration
+
+Configures the network resources of the environment.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#subnetids" title="SubnetIds">SubnetIds</a>" : <i>[ String, ... ]</i>,
+    "<a href="#securitygroupids" title="SecurityGroupIds">SecurityGroupIds</a>" : <i>[ String, ... ]</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#subnetids" title="SubnetIds">SubnetIds</a>: <i>
+      - String</i>
+<a href="#securitygroupids" title="SecurityGroupIds">SecurityGroupIds</a>: <i>
+      - String</i>
+</pre>
+
+## Properties
+
+#### SubnetIds
+
+A list of subnets to use for the environment. These must be private subnets, in the same VPC, in two different availability zones.
+
+_Required_: No
+
+_Type_: List of String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### SecurityGroupIds
+
+A list of security groups to use for the environment.
+
+_Required_: No
+
+_Type_: List of String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/aws-mwaa-environment/pom.xml
+++ b/aws-mwaa-environment/pom.xml
@@ -37,14 +37,14 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>mwaa</artifactId>
-            <version>2.16.43</version>
+            <version>2.21.40</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/software.amazon.awssdk/utils -->
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>utils</artifactId>
-            <version>2.17.42</version>
+            <version>2.21.40</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.assertj/assertj-core -->
@@ -75,6 +75,12 @@
             <version>2.28.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.github.rholder/guava-retrying -->
+        <dependency>
+            <groupId>com.github.rholder</groupId>
+            <artifactId>guava-retrying</artifactId>
+            <version>2.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -86,7 +92,6 @@
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:all,-options,-processing</arg>
-                        <arg>-Werror</arg>
                     </compilerArgs>
                 </configuration>
             </plugin>

--- a/aws-mwaa-environment/src/main/java/software/amazon/mwaa/environment/CreateHandler.java
+++ b/aws-mwaa-environment/src/main/java/software/amazon/mwaa/environment/CreateHandler.java
@@ -55,6 +55,12 @@ public class CreateHandler extends BaseHandlerStd {
                             progress -> getEnvironmentDetails("Create::PostCreateRead", proxies, progress));
                 }
 
+                if (status.get() == EnvironmentStatus.PENDING) {
+                    log("status is PENDING, returning success");
+                    return ProgressEvent.progress(model, callbackContext).then(
+                            progress -> getEnvironmentDetails("Create::PostCreateRead", proxies, progress));
+                }
+
                 if (status.get() == EnvironmentStatus.CREATE_FAILED) {
                     log("status is CREATE_FAILED, returning failure");
                     return ProgressEvent.failed(

--- a/aws-mwaa-environment/src/main/java/software/amazon/mwaa/translator/CreateTranslator.java
+++ b/aws-mwaa-environment/src/main/java/software/amazon/mwaa/translator/CreateTranslator.java
@@ -56,6 +56,7 @@ public final class CreateTranslator {
                         model.getWeeklyMaintenanceWindowStart())
                 .tags(toStringToStringMap(model.getTags()))
                 .webserverAccessMode(model.getWebserverAccessMode())
+                .endpointManagement(model.getEndpointManagement())
                 .build();
     }
 }

--- a/aws-mwaa-environment/src/main/java/software/amazon/mwaa/translator/ReadTranslator.java
+++ b/aws-mwaa-environment/src/main/java/software/amazon/mwaa/translator/ReadTranslator.java
@@ -75,8 +75,12 @@ public final class ReadTranslator {
                 .loggingConfiguration(toCfnLoggingConfiguration(env.loggingConfiguration()))
                 .weeklyMaintenanceWindowStart(env.weeklyMaintenanceWindowStart())
                 .tags(toStringToObjectMap(removeInternalTags(env.tags())))
+                .endpointManagement(env.endpointManagementAsString())
                 .webserverAccessMode(env.webserverAccessModeAsString())
                 .webserverUrl(env.webserverUrl())
+                .celeryExecutorQueue(env.celeryExecutorQueue())
+                .databaseVpcEndpointService(env.databaseVpcEndpointService())
+                .webserverVpcEndpointService(env.webserverVpcEndpointService())
                 .build();
     }
 }

--- a/aws-mwaa-environment/src/test/java/software/amazon/mwaa/environment/HandlerTestBase.java
+++ b/aws-mwaa-environment/src/test/java/software/amazon/mwaa/environment/HandlerTestBase.java
@@ -18,6 +18,7 @@ import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.pagination.sync.SdkIterable;
 import software.amazon.awssdk.services.mwaa.MwaaClient;
+import software.amazon.awssdk.services.mwaa.model.EndpointManagement;
 import software.amazon.awssdk.services.mwaa.model.Environment;
 import software.amazon.awssdk.services.mwaa.model.EnvironmentStatus;
 import software.amazon.awssdk.services.mwaa.model.WebserverAccessMode;
@@ -71,6 +72,7 @@ public class HandlerTestBase {
     private static final String ARN_4 = "ARN_4";
     private static final String ARN_5 = "ARN_5";
     private static final String PRIVATE_ONLY = "PRIVATE_ONLY";
+    private static final String SERVICE = "SERVICE";
     private static final Duration CALLBACK_DELAY = Duration.ofMinutes(1);
 
     private static final int CLIENT_PROXY_TIMEOUT_SECONDS = 600;
@@ -204,6 +206,7 @@ public class HandlerTestBase {
                         new ModuleLoggingConfiguration(ENABLED, LOG_LEVEL_5, ARN_5)))
                 .tags(ImmutableMap.of(KEY, VALUE))
                 .webserverAccessMode(PRIVATE_ONLY)
+                .endpointManagement(SERVICE)
                 .build();
     }
 
@@ -231,6 +234,7 @@ public class HandlerTestBase {
                 .loggingConfiguration(createLoggingConfiguration())
                 .tags(ImmutableMap.of(KEY, VALUE, KEY_INTERNAL, VALUE_INTERNAL))
                 .webserverAccessMode(WebserverAccessMode.PRIVATE_ONLY)
+                .endpointManagement(EndpointManagement.SERVICE)
                 .status(status)
                 .build();
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update MWAA CFN resource provider. Changes include:

- Addition of new input field for `EndpointManagement`
- New read-only fields for `CeleryExecutorQueue`, `DatabaseVpcEndpointService`, and `WebserverVpcEndpointService`
- Updated handlers and translators.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
