### PR TITLE
Upgrade runtimes

### DIFF
--- a/aws-mwaa-environment/.rpdk-config
+++ b/aws-mwaa-environment/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "AWS::MWAA::Environment",
     "language": "java",
-    "runtime": "java8",
+    "runtime": "java17",
     "entrypoint": "software.amazon.mwaa.environment.HandlerWrapper::handleRequest",
     "testEntrypoint": "software.amazon.mwaa.environment.HandlerWrapper::handleRequest",
     "executableEntrypoint": "software.amazon.mwaa.environment.HandlerWrapperExecutable",

--- a/aws-mwaa-environment/template.yml
+++ b/aws-mwaa-environment/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.mwaa.environment.HandlerWrapper::handleRequest
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-mwaa-environment-1.0.jar
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: software.amazon.mwaa.environment.HandlerWrapper::testEntrypoint
-      Runtime: java8
+      Runtime: java17
       CodeUri: ./target/aws-mwaa-environment-1.0.jar
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,8 +2,8 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-        java: openjdk8
-        python: 3.7
+        java: corretto17
+        python: 3.11
     commands:
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:


### PR DESCRIPTION
Upgrade Java runtime from 8 to 17, python from 3.7 to 3.11.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
