### PR TITLE
Update handlers for stack tags

### DIFF
--- a/aws-mwaa-environment/src/main/java/software/amazon/mwaa/translator/CreateTranslator.java
+++ b/aws-mwaa-environment/src/main/java/software/amazon/mwaa/translator/CreateTranslator.java
@@ -6,6 +6,7 @@ import static software.amazon.mwaa.translator.TypeTranslator.toApiLoggingConfigu
 import static software.amazon.mwaa.translator.TypeTranslator.toApiNetworkConfiguration;
 import static software.amazon.mwaa.translator.TypeTranslator.toStringToStringMap;
 
+import java.util.Map;
 import software.amazon.awssdk.services.mwaa.model.CreateEnvironmentRequest;
 import software.amazon.mwaa.environment.ResourceModel;
 
@@ -24,7 +25,8 @@ public final class CreateTranslator {
      *         resource model
      * @return awsRequest the aws service request to create a resource
      */
-    public static CreateEnvironmentRequest translateToCreateRequest(final ResourceModel model) {
+    public static CreateEnvironmentRequest translateToCreateRequest(final ResourceModel model,
+                final Map<String, String> tags) {
 
         return CreateEnvironmentRequest.builder()
                 .name(model.getName())
@@ -47,6 +49,8 @@ public final class CreateTranslator {
                 .environmentClass(model.getEnvironmentClass())
                 .maxWorkers(model.getMaxWorkers())
                 .minWorkers(model.getMinWorkers())
+                .maxWebservers(model.getMaxWebservers())
+                .minWebservers(model.getMinWebservers())
                 .schedulers(model.getSchedulers())
                 .networkConfiguration(toApiNetworkConfiguration(
                         model.getNetworkConfiguration()))
@@ -54,7 +58,7 @@ public final class CreateTranslator {
                         model.getLoggingConfiguration()))
                 .weeklyMaintenanceWindowStart(
                         model.getWeeklyMaintenanceWindowStart())
-                .tags(toStringToStringMap(model.getTags()))
+                .tags(!tags.isEmpty() ? tags : null)
                 .webserverAccessMode(model.getWebserverAccessMode())
                 .endpointManagement(model.getEndpointManagement())
                 .build();

--- a/aws-mwaa-environment/src/test/java/software/amazon/mwaa/environment/CreateHandlerTest.java
+++ b/aws-mwaa-environment/src/test/java/software/amazon/mwaa/environment/CreateHandlerTest.java
@@ -12,6 +12,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import java.util.HashMap;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -128,8 +131,10 @@ public class CreateHandlerTest extends HandlerTestBase {
         // given
         final CreateHandler handler = new CreateHandler();
         final ResourceModel model = createCfnModel();
+        final Map<String, String> tags = ImmutableMap.of("Key", "Value");
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .desiredResourceTags(tags)
                 .build();
         final GetEnvironmentResponse creating = createGetCreatingEnvironmentResponse();
         final GetEnvironmentResponse pending = createGetPendingEnvironmentResponse();
@@ -267,7 +272,9 @@ public class CreateHandlerTest extends HandlerTestBase {
                 .desiredResourceState(model)
                 .build();
         final GetEnvironmentRequest awsGetEnvironmentRequest = ReadTranslator.translateToReadRequest(model);
-        final CreateEnvironmentRequest awsCreateEnvironmentRequest = CreateTranslator.translateToCreateRequest(model);
+        final Map<String, String> tags = new HashMap<>();
+        final CreateEnvironmentRequest awsCreateEnvironmentRequest = CreateTranslator.translateToCreateRequest(
+                model, tags);
         ProxyClient<MwaaClient> mwaaClientProxy = getProxies().getMwaaClientProxy();
 
         // when
@@ -306,7 +313,9 @@ public class CreateHandlerTest extends HandlerTestBase {
                 .desiredResourceState(model)
                 .build();
         final GetEnvironmentRequest awsGetEnvironmentRequest = ReadTranslator.translateToReadRequest(model);
-        final CreateEnvironmentRequest awsCreateEnvironmentRequest = CreateTranslator.translateToCreateRequest(model);
+        final Map<String, String> tags = new HashMap<>();
+        final CreateEnvironmentRequest awsCreateEnvironmentRequest = CreateTranslator.translateToCreateRequest(
+                model, tags);
         final CreateEnvironmentResponse createEnvironmentResponse = CreateEnvironmentResponse.builder().build();
 
         ProxyClient<MwaaClient> mwaaClientProxy = getProxies().getMwaaClientProxy();
@@ -346,7 +355,9 @@ public class CreateHandlerTest extends HandlerTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
                 .build();
-        final CreateEnvironmentRequest awsCreateEnvironmentRequest = CreateTranslator.translateToCreateRequest(model);
+        final Map<String, String> tags = new HashMap<>();
+        final CreateEnvironmentRequest awsCreateEnvironmentRequest = CreateTranslator.translateToCreateRequest(
+                model, tags);
         final GetEnvironmentRequest awsGetEnvironmentRequest = ReadTranslator.translateToReadRequest(model);
 
         ProxyClient<MwaaClient> mwaaClientProxy = getProxies().getMwaaClientProxy();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update create and update handlers to include system and stack tags. Also prevent update from read tags directly from the environment, but use the previous cloudformation state instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
